### PR TITLE
Skeary moov parsing fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ Box.decodeWithoutHeaders = function (headers, buffer, start, end) {
     }
   } else if (boxes[type]) {
     var decode = boxes[type].decode
-    obj = decode(buffer, start, end)
+    obj = decode(buffer, start, end, headers)
   } else {
     obj.buffer = bufferFrom(buffer.slice(start, end))
   }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var Box = exports
  * Five-character names ending in 's' indicate arrays instead of single elements.
  */
 var containers = exports.containers = {
-  'moov': ['mvhd', 'meta', 'traks', 'mvex'],
+  'moov': ['mvhd', 'meta', 'traks', 'mvex', 'udta'],
   'trak': ['tkhd', 'tref', 'trgr', 'edts', 'meta', 'mdia', 'udta'],
   'edts': ['elst'],
   'mdia': ['mdhd', 'hdlr', 'elng', 'minf'],


### PR DESCRIPTION
Hi,

Great library :)

Here are some changes I had to implement in order to be able to correctly decode and re-encode some mp4 files I was generating from ffmpeg:

* I've modified the library to support a **udta** box inside a **moof** box. From reading the specs I understand it is legitimate for a **moof** to contain a **udta** box and this is what I was seeing with my sample mp4s.
* I've updated the decoding and encoding support for **tfhd**, **tfdt** and **trun** boxes to be more robust. I've done this based on my reading of the spec so I believe it should work for all mp4 files. Previously, the code made various assumptions about fields being there and overall didn't look complete. In order to make the decoding more robust, it is important to know what is in the flags header as this drives what optional fields are present in the boxes. As a result, I've modified the `decodeWithoutHeaders()` function to pass through the headers object to the `decode()` functions for the box decoders. This means the `decode()` functions can use the flag info to correctly decode the boxes.

On my sample mp4 files, I was able to correctly decode and re-encode them with the provided changes. I also checked the resultant box contents manually with the MP4Box.js file viewer (https://gpac.github.io/mp4box.js/test/filereader.html)

Could you please review and see if you think this is suitable to be merged in? Happy to make any required changes.

Cheers,
Simon 
