### PR TITLE
use const and let

### DIFF
--- a/boxes.js
+++ b/boxes.js
@@ -1,9 +1,9 @@
 // This is an intentionally recursive require. I don't like it either.
-var Box = require('./index')
-var Descriptor = require('./descriptor')
-var uint64be = require('uint64be')
+const uint64be = require('uint64be')
+const Box = require('./index.js')
+const Descriptor = require('./descriptor.js')
 
-var TIME_OFFSET = 2082844800000
+const TIME_OFFSET = 2082844800000
 
 /*
 TODO:
@@ -13,7 +13,7 @@ add new box versions
 
 // These have 'version' and 'flags' fields in the headers
 exports.fullBoxes = {}
-var fullBoxes = [
+const fullBoxes = [
   'mvhd',
   'tkhd',
   'mdhd',
@@ -38,907 +38,881 @@ var fullBoxes = [
   'tfdt',
   'trun'
 ]
-fullBoxes.forEach(function (type) {
+fullBoxes.forEach(type => {
   exports.fullBoxes[type] = true
 })
 
-exports.ftyp = {}
-exports.ftyp.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.ftyp.encodingLength(box))
-  var brands = box.compatibleBrands || []
-  buf.write(box.brand, 0, 4, 'ascii')
-  buf.writeUInt32BE(box.brandVersion, 4)
-  for (var i = 0; i < brands.length; i++) buf.write(brands[i], 8 + (i * 4), 4, 'ascii')
-  exports.ftyp.encode.bytes = 8 + brands.length * 4
-  return buf
-}
-exports.ftyp.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var brand = buf.toString('ascii', 0, 4)
-  var version = buf.readUInt32BE(4)
-  var compatibleBrands = []
-  for (var i = 8; i < buf.length; i += 4) compatibleBrands.push(buf.toString('ascii', i, i + 4))
-  return {
-    brand: brand,
-    brandVersion: version,
-    compatibleBrands: compatibleBrands
-  }
-}
-exports.ftyp.encodingLength = function (box) {
-  return 8 + (box.compatibleBrands || []).length * 4
-}
-
-exports.mvhd = {}
-exports.mvhd.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(96)
-  writeDate(box.ctime || new Date(), buf, 0)
-  writeDate(box.mtime || new Date(), buf, 4)
-  buf.writeUInt32BE(box.timeScale || 0, 8)
-  buf.writeUInt32BE(box.duration || 0, 12)
-  writeFixed32(box.preferredRate || 0, buf, 16)
-  writeFixed16(box.preferredVolume || 0, buf, 20)
-  writeReserved(buf, 22, 32)
-  writeMatrix(box.matrix, buf, 32)
-  buf.writeUInt32BE(box.previewTime || 0, 68)
-  buf.writeUInt32BE(box.previewDuration || 0, 72)
-  buf.writeUInt32BE(box.posterTime || 0, 76)
-  buf.writeUInt32BE(box.selectionTime || 0, 80)
-  buf.writeUInt32BE(box.selectionDuration || 0, 84)
-  buf.writeUInt32BE(box.currentTime || 0, 88)
-  buf.writeUInt32BE(box.nextTrackId || 0, 92)
-  exports.mvhd.encode.bytes = 96
-  return buf
-}
-exports.mvhd.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  return {
-    ctime: readDate(buf, 0),
-    mtime: readDate(buf, 4),
-    timeScale: buf.readUInt32BE(8),
-    duration: buf.readUInt32BE(12),
-    preferredRate: readFixed32(buf, 16),
-    preferredVolume: readFixed16(buf, 20),
-    matrix: readMatrix(buf.slice(32, 68)),
-    previewTime: buf.readUInt32BE(68),
-    previewDuration: buf.readUInt32BE(72),
-    posterTime: buf.readUInt32BE(76),
-    selectionTime: buf.readUInt32BE(80),
-    selectionDuration: buf.readUInt32BE(84),
-    currentTime: buf.readUInt32BE(88),
-    nextTrackId: buf.readUInt32BE(92)
-  }
-}
-exports.mvhd.encodingLength = function (box) {
-  return 96
-}
-
-exports.tkhd = {}
-exports.tkhd.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(80)
-  writeDate(box.ctime || new Date(), buf, 0)
-  writeDate(box.mtime || new Date(), buf, 4)
-  buf.writeUInt32BE(box.trackId || 0, 8)
-  writeReserved(buf, 12, 16)
-  buf.writeUInt32BE(box.duration || 0, 16)
-  writeReserved(buf, 20, 28)
-  buf.writeUInt16BE(box.layer || 0, 28)
-  buf.writeUInt16BE(box.alternateGroup || 0, 30)
-  buf.writeUInt16BE(box.volume || 0, 32)
-  writeMatrix(box.matrix, buf, 36)
-  buf.writeUInt32BE(box.trackWidth || 0, 72)
-  buf.writeUInt32BE(box.trackHeight || 0, 76)
-  exports.tkhd.encode.bytes = 80
-  return buf
-}
-exports.tkhd.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  return {
-    ctime: readDate(buf, 0),
-    mtime: readDate(buf, 4),
-    trackId: buf.readUInt32BE(8),
-    duration: buf.readUInt32BE(16),
-    layer: buf.readUInt16BE(28),
-    alternateGroup: buf.readUInt16BE(30),
-    volume: buf.readUInt16BE(32),
-    matrix: readMatrix(buf.slice(36, 72)),
-    trackWidth: buf.readUInt32BE(72),
-    trackHeight: buf.readUInt32BE(76)
-  }
-}
-exports.tkhd.encodingLength = function (box) {
-  return 80
-}
-
-exports.mdhd = {}
-exports.mdhd.encode = function (box, buf, offset) {
-  if (box.version === 1) {
-    buf = buf ? buf.slice(offset) : Buffer.alloc(32)
-    writeDate64(box.ctime || new Date(), buf, 0)
-    writeDate64(box.mtime || new Date(), buf, 8)
-    buf.writeUInt32BE(box.timeScale || 0, 16)
-    // Node only supports integer <= 48bit. Waiting for BigInt!
-    buf.writeUIntBE(box.duration || 0, 20, 6)
-    buf.writeUInt16BE(box.language || 0, 28)
-    buf.writeUInt16BE(box.quality || 0, 30)
-    exports.mdhd.encode.bytes = 32
+exports.ftyp = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.ftyp.encodingLength(box))
+    const brands = box.compatibleBrands || []
+    buf.write(box.brand, 0, 4, 'ascii')
+    buf.writeUInt32BE(box.brandVersion, 4)
+    for (let i = 0; i < brands.length; i++) buf.write(brands[i], 8 + (i * 4), 4, 'ascii')
+    exports.ftyp.encode.bytes = 8 + brands.length * 4
     return buf
-  }
-
-  buf = buf ? buf.slice(offset) : Buffer.alloc(20)
-  writeDate(box.ctime || new Date(), buf, 0)
-  writeDate(box.mtime || new Date(), buf, 4)
-  buf.writeUInt32BE(box.timeScale || 0, 8)
-  buf.writeUInt32BE(box.duration || 0, 12)
-  buf.writeUInt16BE(box.language || 0, 16)
-  buf.writeUInt16BE(box.quality || 0, 18)
-  exports.mdhd.encode.bytes = 20
-  return buf
-}
-
-exports.mdhd.decode = function (buf, offset, end) {
-  buf = buf.slice(offset)
-
-  var version1 = (end - offset) !== 20
-
-  // In version 1 creation time and modification time are unsigned long
-  if (version1) {
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const brand = buf.toString('ascii', 0, 4)
+    const version = buf.readUInt32BE(4)
+    const compatibleBrands = []
+    for (let i = 8; i < buf.length; i += 4) compatibleBrands.push(buf.toString('ascii', i, i + 4))
     return {
-      ctime: readDate64(buf, 0),
-      mtime: readDate64(buf, 8),
-      timeScale: buf.readUInt32BE(16),
+      brand,
+      brandVersion: version,
+      compatibleBrands
+    }
+  },
+  encodingLength: box => 8 + (box.compatibleBrands || []).length * 4
+}
+
+exports.mvhd = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(96)
+    writeDate(box.ctime || new Date(), buf, 0)
+    writeDate(box.mtime || new Date(), buf, 4)
+    buf.writeUInt32BE(box.timeScale || 0, 8)
+    buf.writeUInt32BE(box.duration || 0, 12)
+    writeFixed32(box.preferredRate || 0, buf, 16)
+    writeFixed16(box.preferredVolume || 0, buf, 20)
+    writeReserved(buf, 22, 32)
+    writeMatrix(box.matrix, buf, 32)
+    buf.writeUInt32BE(box.previewTime || 0, 68)
+    buf.writeUInt32BE(box.previewDuration || 0, 72)
+    buf.writeUInt32BE(box.posterTime || 0, 76)
+    buf.writeUInt32BE(box.selectionTime || 0, 80)
+    buf.writeUInt32BE(box.selectionDuration || 0, 84)
+    buf.writeUInt32BE(box.currentTime || 0, 88)
+    buf.writeUInt32BE(box.nextTrackId || 0, 92)
+    exports.mvhd.encode.bytes = 96
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    return {
+      ctime: readDate(buf, 0),
+      mtime: readDate(buf, 4),
+      timeScale: buf.readUInt32BE(8),
+      duration: buf.readUInt32BE(12),
+      preferredRate: readFixed32(buf, 16),
+      preferredVolume: readFixed16(buf, 20),
+      matrix: readMatrix(buf.slice(32, 68)),
+      previewTime: buf.readUInt32BE(68),
+      previewDuration: buf.readUInt32BE(72),
+      posterTime: buf.readUInt32BE(76),
+      selectionTime: buf.readUInt32BE(80),
+      selectionDuration: buf.readUInt32BE(84),
+      currentTime: buf.readUInt32BE(88),
+      nextTrackId: buf.readUInt32BE(92)
+    }
+  },
+  encodingLength: box => 96
+}
+
+exports.tkhd = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(80)
+    writeDate(box.ctime || new Date(), buf, 0)
+    writeDate(box.mtime || new Date(), buf, 4)
+    buf.writeUInt32BE(box.trackId || 0, 8)
+    writeReserved(buf, 12, 16)
+    buf.writeUInt32BE(box.duration || 0, 16)
+    writeReserved(buf, 20, 28)
+    buf.writeUInt16BE(box.layer || 0, 28)
+    buf.writeUInt16BE(box.alternateGroup || 0, 30)
+    buf.writeUInt16BE(box.volume || 0, 32)
+    writeMatrix(box.matrix, buf, 36)
+    buf.writeUInt32BE(box.trackWidth || 0, 72)
+    buf.writeUInt32BE(box.trackHeight || 0, 76)
+    exports.tkhd.encode.bytes = 80
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    return {
+      ctime: readDate(buf, 0),
+      mtime: readDate(buf, 4),
+      trackId: buf.readUInt32BE(8),
+      duration: buf.readUInt32BE(16),
+      layer: buf.readUInt16BE(28),
+      alternateGroup: buf.readUInt16BE(30),
+      volume: buf.readUInt16BE(32),
+      matrix: readMatrix(buf.slice(36, 72)),
+      trackWidth: buf.readUInt32BE(72),
+      trackHeight: buf.readUInt32BE(76)
+    }
+  },
+  encodingLength: box => 80
+}
+
+exports.mdhd = {
+  encode (box, buf, offset) {
+    if (box.version === 1) {
+      buf = buf ? buf.slice(offset) : Buffer.alloc(32)
+      writeDate64(box.ctime || new Date(), buf, 0)
+      writeDate64(box.mtime || new Date(), buf, 8)
+      buf.writeUInt32BE(box.timeScale || 0, 16)
       // Node only supports integer <= 48bit. Waiting for BigInt!
-      duration: buf.readUIntBE(20, 6),
-      language: buf.readUInt16BE(28),
-      quality: buf.readUInt16BE(30)
+      buf.writeUIntBE(box.duration || 0, 20, 6)
+      buf.writeUInt16BE(box.language || 0, 28)
+      buf.writeUInt16BE(box.quality || 0, 30)
+      exports.mdhd.encode.bytes = 32
+      return buf
     }
-  }
 
-  return {
-    ctime: readDate(buf, 0),
-    mtime: readDate(buf, 4),
-    timeScale: buf.readUInt32BE(8),
-    duration: buf.readUInt32BE(12),
-    language: buf.readUInt16BE(16),
-    quality: buf.readUInt16BE(18)
-  }
-}
-exports.mdhd.encodingLength = function (box) {
-  if (box.version === 1) return 32
+    buf = buf ? buf.slice(offset) : Buffer.alloc(20)
+    writeDate(box.ctime || new Date(), buf, 0)
+    writeDate(box.mtime || new Date(), buf, 4)
+    buf.writeUInt32BE(box.timeScale || 0, 8)
+    buf.writeUInt32BE(box.duration || 0, 12)
+    buf.writeUInt16BE(box.language || 0, 16)
+    buf.writeUInt16BE(box.quality || 0, 18)
+    exports.mdhd.encode.bytes = 20
+    return buf
+  },
+  decode (buf, offset, end) {
+    buf = buf.slice(offset)
 
-  return 20
-}
+    const version1 = (end - offset) !== 20
 
-exports.vmhd = {}
-exports.vmhd.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(8)
-  buf.writeUInt16BE(box.graphicsMode || 0, 0)
-  var opcolor = box.opcolor || [0, 0, 0]
-  buf.writeUInt16BE(opcolor[0], 2)
-  buf.writeUInt16BE(opcolor[1], 4)
-  buf.writeUInt16BE(opcolor[2], 6)
-  exports.vmhd.encode.bytes = 8
-  return buf
-}
-exports.vmhd.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  return {
-    graphicsMode: buf.readUInt16BE(0),
-    opcolor: [buf.readUInt16BE(2), buf.readUInt16BE(4), buf.readUInt16BE(6)]
-  }
-}
-exports.vmhd.encodingLength = function (box) {
-  return 8
-}
-
-exports.smhd = {}
-exports.smhd.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(4)
-  buf.writeUInt16BE(box.balance || 0, 0)
-  writeReserved(buf, 2, 4)
-  exports.smhd.encode.bytes = 4
-  return buf
-}
-exports.smhd.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  return {
-    balance: buf.readUInt16BE(0)
-  }
-}
-exports.smhd.encodingLength = function (box) {
-  return 4
-}
-
-exports.stsd = {}
-exports.stsd.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stsd.encodingLength(box))
-  var entries = box.entries || []
-
-  buf.writeUInt32BE(entries.length, 0)
-
-  var ptr = 4
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i]
-    Box.encode(entry, buf, ptr)
-    ptr += Box.encode.bytes
-  }
-
-  exports.stsd.encode.bytes = ptr
-  return buf
-}
-exports.stsd.decode = function (buf, offset, end) {
-  buf = buf.slice(offset)
-  var num = buf.readUInt32BE(0)
-  var entries = new Array(num)
-  var ptr = 4
-
-  for (var i = 0; i < num; i++) {
-    var entry = Box.decode(buf, ptr, end)
-    entries[i] = entry
-    ptr += entry.length
-  }
-
-  return {
-    entries: entries
-  }
-}
-exports.stsd.encodingLength = function (box) {
-  var totalSize = 4
-  if (!box.entries) return totalSize
-  for (var i = 0; i < box.entries.length; i++) {
-    totalSize += Box.encodingLength(box.entries[i])
-  }
-  return totalSize
-}
-
-exports.avc1 = exports.VisualSampleEntry = {}
-exports.VisualSampleEntry.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.VisualSampleEntry.encodingLength(box))
-
-  writeReserved(buf, 0, 6)
-  buf.writeUInt16BE(box.dataReferenceIndex || 0, 6)
-  writeReserved(buf, 8, 24)
-  buf.writeUInt16BE(box.width || 0, 24)
-  buf.writeUInt16BE(box.height || 0, 26)
-  buf.writeUInt32BE(box.hResolution || 0x480000, 28)
-  buf.writeUInt32BE(box.vResolution || 0x480000, 32)
-  writeReserved(buf, 36, 40)
-  buf.writeUInt16BE(box.frameCount || 1, 40)
-  var compressorName = box.compressorName || ''
-  var nameLen = Math.min(compressorName.length, 31)
-  buf.writeUInt8(nameLen, 42)
-  buf.write(compressorName, 43, nameLen, 'utf8')
-  buf.writeUInt16BE(box.depth || 0x18, 74)
-  buf.writeInt16BE(-1, 76)
-
-  var ptr = 78
-  var children = box.children || []
-  children.forEach(function (child) {
-    Box.encode(child, buf, ptr)
-    ptr += Box.encode.bytes
-  })
-  exports.VisualSampleEntry.encode.bytes = ptr
-}
-exports.VisualSampleEntry.decode = function (buf, offset, end) {
-  buf = buf.slice(offset)
-  var length = end - offset
-  var nameLen = Math.min(buf.readUInt8(42), 31)
-  var box = {
-    dataReferenceIndex: buf.readUInt16BE(6),
-    width: buf.readUInt16BE(24),
-    height: buf.readUInt16BE(26),
-    hResolution: buf.readUInt32BE(28),
-    vResolution: buf.readUInt32BE(32),
-    frameCount: buf.readUInt16BE(40),
-    compressorName: buf.toString('utf8', 43, 43 + nameLen),
-    depth: buf.readUInt16BE(74),
-    children: []
-  }
-
-  var ptr = 78
-  while (length - ptr >= 8) {
-    var child = Box.decode(buf, ptr, length)
-    box.children.push(child)
-    box[child.type] = child
-    ptr += child.length
-  }
-
-  return box
-}
-exports.VisualSampleEntry.encodingLength = function (box) {
-  var len = 78
-  var children = box.children || []
-  children.forEach(function (child) {
-    len += Box.encodingLength(child)
-  })
-  return len
-}
-
-exports.avcC = {}
-exports.avcC.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(box.buffer.length)
-
-  box.buffer.copy(buf)
-  exports.avcC.encode.bytes = box.buffer.length
-}
-exports.avcC.decode = function (buf, offset, end) {
-  buf = buf.slice(offset, end)
-
-  return {
-    mimeCodec: buf.toString('hex', 1, 4),
-    buffer: Buffer.from(buf)
-  }
-}
-exports.avcC.encodingLength = function (box) {
-  return box.buffer.length
-}
-
-exports.mp4a = exports.AudioSampleEntry = {}
-exports.AudioSampleEntry.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.AudioSampleEntry.encodingLength(box))
-
-  writeReserved(buf, 0, 6)
-  buf.writeUInt16BE(box.dataReferenceIndex || 0, 6)
-  writeReserved(buf, 8, 16)
-  buf.writeUInt16BE(box.channelCount || 2, 16)
-  buf.writeUInt16BE(box.sampleSize || 16, 18)
-  writeReserved(buf, 20, 24)
-  buf.writeUInt32BE(box.sampleRate || 0, 24)
-
-  var ptr = 28
-  var children = box.children || []
-  children.forEach(function (child) {
-    Box.encode(child, buf, ptr)
-    ptr += Box.encode.bytes
-  })
-  exports.AudioSampleEntry.encode.bytes = ptr
-}
-exports.AudioSampleEntry.decode = function (buf, offset, end) {
-  buf = buf.slice(offset, end)
-  var length = end - offset
-  var box = {
-    dataReferenceIndex: buf.readUInt16BE(6),
-    channelCount: buf.readUInt16BE(16),
-    sampleSize: buf.readUInt16BE(18),
-    sampleRate: buf.readUInt32BE(24),
-    children: []
-  }
-
-  var ptr = 28
-  while (length - ptr >= 8) {
-    var child = Box.decode(buf, ptr, length)
-    box.children.push(child)
-    box[child.type] = child
-    ptr += child.length
-  }
-
-  return box
-}
-exports.AudioSampleEntry.encodingLength = function (box) {
-  var len = 28
-  var children = box.children || []
-  children.forEach(function (child) {
-    len += Box.encodingLength(child)
-  })
-  return len
-}
-
-exports.esds = {}
-exports.esds.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(box.buffer.length)
-
-  box.buffer.copy(buf, 0)
-  exports.esds.encode.bytes = box.buffer.length
-}
-exports.esds.decode = function (buf, offset, end) {
-  buf = buf.slice(offset, end)
-
-  var desc = Descriptor.Descriptor.decode(buf, 0, buf.length)
-  var esd = (desc.tagName === 'ESDescriptor') ? desc : {}
-  var dcd = esd.DecoderConfigDescriptor || {}
-  var oti = dcd.oti || 0
-  var dsi = dcd.DecoderSpecificInfo
-  var audioConfig = dsi ? (dsi.buffer.readUInt8(0) & 0xf8) >> 3 : 0
-
-  var mimeCodec = null
-  if (oti) {
-    mimeCodec = oti.toString(16)
-    if (audioConfig) {
-      mimeCodec += '.' + audioConfig
+    // In version 1 creation time and modification time are unsigned long
+    if (version1) {
+      return {
+        ctime: readDate64(buf, 0),
+        mtime: readDate64(buf, 8),
+        timeScale: buf.readUInt32BE(16),
+        // Node only supports integer <= 48bit. Waiting for BigInt!
+        duration: buf.readUIntBE(20, 6),
+        language: buf.readUInt16BE(28),
+        quality: buf.readUInt16BE(30)
+      }
     }
-  }
 
-  return {
-    mimeCodec: mimeCodec,
-    buffer: Buffer.from(buf.slice(0))
+    return {
+      ctime: readDate(buf, 0),
+      mtime: readDate(buf, 4),
+      timeScale: buf.readUInt32BE(8),
+      duration: buf.readUInt32BE(12),
+      language: buf.readUInt16BE(16),
+      quality: buf.readUInt16BE(18)
+    }
+  },
+  encodingLength: box => box.version === 1 ? 32 : 20
+}
+
+exports.vmhd = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(8)
+    buf.writeUInt16BE(box.graphicsMode || 0, 0)
+    const opcolor = box.opcolor || [0, 0, 0]
+    buf.writeUInt16BE(opcolor[0], 2)
+    buf.writeUInt16BE(opcolor[1], 4)
+    buf.writeUInt16BE(opcolor[2], 6)
+    exports.vmhd.encode.bytes = 8
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    return {
+      graphicsMode: buf.readUInt16BE(0),
+      opcolor: [buf.readUInt16BE(2), buf.readUInt16BE(4), buf.readUInt16BE(6)]
+    }
+  },
+  encodingLength: box => 8
+}
+
+exports.smhd = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(4)
+    buf.writeUInt16BE(box.balance || 0, 0)
+    writeReserved(buf, 2, 4)
+    exports.smhd.encode.bytes = 4
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    return {
+      balance: buf.readUInt16BE(0)
+    }
+  },
+  encodingLength: box => 4
+}
+
+exports.stsd = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stsd.encodingLength(box))
+    const entries = box.entries || []
+
+    buf.writeUInt32BE(entries.length, 0)
+
+    let ptr = 4
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]
+      Box.encode(entry, buf, ptr)
+      ptr += Box.encode.bytes
+    }
+
+    exports.stsd.encode.bytes = ptr
+    return buf
+  },
+  decode (buf, offset, end) {
+    buf = buf.slice(offset)
+    const num = buf.readUInt32BE(0)
+    const entries = new Array(num)
+    let ptr = 4
+
+    for (let i = 0; i < num; i++) {
+      const entry = Box.decode(buf, ptr, end)
+      entries[i] = entry
+      ptr += entry.length
+    }
+
+    return {
+      entries
+    }
+  },
+  encodingLength (box) {
+    let totalSize = 4
+    if (!box.entries) return totalSize
+    for (let i = 0; i < box.entries.length; i++) {
+      totalSize += Box.encodingLength(box.entries[i])
+    }
+    return totalSize
   }
 }
-exports.esds.encodingLength = function (box) {
-  return box.buffer.length
+
+exports.avc1 =
+exports.VisualSampleEntry = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.VisualSampleEntry.encodingLength(box))
+
+    writeReserved(buf, 0, 6)
+    buf.writeUInt16BE(box.dataReferenceIndex || 0, 6)
+    writeReserved(buf, 8, 24)
+    buf.writeUInt16BE(box.width || 0, 24)
+    buf.writeUInt16BE(box.height || 0, 26)
+    buf.writeUInt32BE(box.hResolution || 0x480000, 28)
+    buf.writeUInt32BE(box.vResolution || 0x480000, 32)
+    writeReserved(buf, 36, 40)
+    buf.writeUInt16BE(box.frameCount || 1, 40)
+    const compressorName = box.compressorName || ''
+    const nameLen = Math.min(compressorName.length, 31)
+    buf.writeUInt8(nameLen, 42)
+    buf.write(compressorName, 43, nameLen, 'utf8')
+    buf.writeUInt16BE(box.depth || 0x18, 74)
+    buf.writeInt16BE(-1, 76)
+
+    let ptr = 78
+    const children = box.children || []
+    children.forEach(child => {
+      Box.encode(child, buf, ptr)
+      ptr += Box.encode.bytes
+    })
+    exports.VisualSampleEntry.encode.bytes = ptr
+  },
+  decode (buf, offset, end) {
+    buf = buf.slice(offset)
+    const length = end - offset
+    const nameLen = Math.min(buf.readUInt8(42), 31)
+    const box = {
+      dataReferenceIndex: buf.readUInt16BE(6),
+      width: buf.readUInt16BE(24),
+      height: buf.readUInt16BE(26),
+      hResolution: buf.readUInt32BE(28),
+      vResolution: buf.readUInt32BE(32),
+      frameCount: buf.readUInt16BE(40),
+      compressorName: buf.toString('utf8', 43, 43 + nameLen),
+      depth: buf.readUInt16BE(74),
+      children: []
+    }
+
+    let ptr = 78
+    while (length - ptr >= 8) {
+      const child = Box.decode(buf, ptr, length)
+      box.children.push(child)
+      box[child.type] = child
+      ptr += child.length
+    }
+
+    return box
+  },
+  encodingLength (box) {
+    let len = 78
+    const children = box.children || []
+    children.forEach(child => {
+      len += Box.encodingLength(child)
+    })
+    return len
+  }
+}
+
+exports.avcC = {
+  encode ({ buffer }, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(buffer.length)
+
+    buffer.copy(buf)
+    exports.avcC.encode.bytes = buffer.length
+  },
+  decode (buf, offset, end) {
+    buf = buf.slice(offset, end)
+
+    return {
+      mimeCodec: buf.toString('hex', 1, 4),
+      buffer: Buffer.from(buf)
+    }
+  },
+  encodingLength: box => box.buffer.length
+}
+
+exports.mp4a =
+exports.AudioSampleEntry = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.AudioSampleEntry.encodingLength(box))
+
+    writeReserved(buf, 0, 6)
+    buf.writeUInt16BE(box.dataReferenceIndex || 0, 6)
+    writeReserved(buf, 8, 16)
+    buf.writeUInt16BE(box.channelCount || 2, 16)
+    buf.writeUInt16BE(box.sampleSize || 16, 18)
+    writeReserved(buf, 20, 24)
+    buf.writeUInt32BE(box.sampleRate || 0, 24)
+
+    let ptr = 28
+    const children = box.children || []
+    children.forEach(child => {
+      Box.encode(child, buf, ptr)
+      ptr += Box.encode.bytes
+    })
+    exports.AudioSampleEntry.encode.bytes = ptr
+  },
+  decode (buf, offset, end) {
+    buf = buf.slice(offset, end)
+    const length = end - offset
+    const box = {
+      dataReferenceIndex: buf.readUInt16BE(6),
+      channelCount: buf.readUInt16BE(16),
+      sampleSize: buf.readUInt16BE(18),
+      sampleRate: buf.readUInt32BE(24),
+      children: []
+    }
+
+    let ptr = 28
+    while (length - ptr >= 8) {
+      const child = Box.decode(buf, ptr, length)
+      box.children.push(child)
+      box[child.type] = child
+      ptr += child.length
+    }
+
+    return box
+  },
+  encodingLength (box) {
+    let len = 28
+    const children = box.children || []
+    children.forEach(child => {
+      len += Box.encodingLength(child)
+    })
+    return len
+  }
+}
+
+exports.esds = {
+  encode ({ buffer }, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(buffer.length)
+
+    buffer.copy(buf, 0)
+    exports.esds.encode.bytes = buffer.length
+  },
+  decode (buf, offset, end) {
+    buf = buf.slice(offset, end)
+
+    const desc = Descriptor.Descriptor.decode(buf, 0, buf.length)
+    const esd = (desc.tagName === 'ESDescriptor') ? desc : {}
+    const dcd = esd.DecoderConfigDescriptor || {}
+    const oti = dcd.oti || 0
+    const dsi = dcd.DecoderSpecificInfo
+    const audioConfig = dsi ? (dsi.buffer.readUInt8(0) & 0xf8) >> 3 : 0
+
+    let mimeCodec = null
+    if (oti) {
+      mimeCodec = oti.toString(16)
+      if (audioConfig) {
+        mimeCodec += `.${audioConfig}`
+      }
+    }
+
+    return {
+      mimeCodec,
+      buffer: Buffer.from(buf.slice(0))
+    }
+  },
+  encodingLength: box => box.buffer.length
 }
 
 // TODO: integrate the two versions in a saner way
-exports.stsz = {}
-exports.stsz.encode = function (box, buf, offset) {
-  var entries = box.entries || []
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stsz.encodingLength(box))
+exports.stsz = {
+  encode (box, buf, offset) {
+    const entries = box.entries || []
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stsz.encodingLength(box))
 
-  buf.writeUInt32BE(0, 0)
-  buf.writeUInt32BE(entries.length, 4)
+    buf.writeUInt32BE(0, 0)
+    buf.writeUInt32BE(entries.length, 4)
 
-  for (var i = 0; i < entries.length; i++) {
-    buf.writeUInt32BE(entries[i], i * 4 + 8)
-  }
-
-  exports.stsz.encode.bytes = 8 + entries.length * 4
-  return buf
-}
-exports.stsz.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var size = buf.readUInt32BE(0)
-  var num = buf.readUInt32BE(4)
-  var entries = new Array(num)
-
-  for (var i = 0; i < num; i++) {
-    if (size === 0) {
-      entries[i] = buf.readUInt32BE(i * 4 + 8)
-    } else {
-      entries[i] = size
+    for (let i = 0; i < entries.length; i++) {
+      buf.writeUInt32BE(entries[i], i * 4 + 8)
     }
-  }
 
-  return {
-    entries: entries
-  }
-}
-exports.stsz.encodingLength = function (box) {
-  return 8 + box.entries.length * 4
+    exports.stsz.encode.bytes = 8 + entries.length * 4
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const size = buf.readUInt32BE(0)
+    const num = buf.readUInt32BE(4)
+    const entries = new Array(num)
+
+    for (let i = 0; i < num; i++) {
+      if (size === 0) {
+        entries[i] = buf.readUInt32BE(i * 4 + 8)
+      } else {
+        entries[i] = size
+      }
+    }
+
+    return {
+      entries
+    }
+  },
+  encodingLength: box => 8 + box.entries.length * 4
 }
 
 exports.stss =
-exports.stco = {}
-exports.stco.encode = function (box, buf, offset) {
-  var entries = box.entries || []
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stco.encodingLength(box))
+exports.stco = {
+  encode (box, buf, offset) {
+    const entries = box.entries || []
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stco.encodingLength(box))
 
-  buf.writeUInt32BE(entries.length, 0)
+    buf.writeUInt32BE(entries.length, 0)
 
-  for (var i = 0; i < entries.length; i++) {
-    buf.writeUInt32BE(entries[i], i * 4 + 4)
-  }
-
-  exports.stco.encode.bytes = 4 + entries.length * 4
-  return buf
-}
-exports.stco.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var num = buf.readUInt32BE(0)
-  var entries = new Array(num)
-
-  for (var i = 0; i < num; i++) {
-    entries[i] = buf.readUInt32BE(i * 4 + 4)
-  }
-
-  return {
-    entries: entries
-  }
-}
-exports.stco.encodingLength = function (box) {
-  return 4 + box.entries.length * 4
-}
-
-exports.co64 = {}
-exports.co64.encode = function (box, buf, offset) {
-  var entries = box.entries || []
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.co64.encodingLength(box))
-
-  buf.writeUInt32BE(entries.length, 0)
-
-  for (var i = 0; i < entries.length; i++) {
-    uint64be.encode(entries[i], buf, i * 8 + 4)
-  }
-
-  exports.co64.encode.bytes = 4 + entries.length * 8
-  return buf
-}
-exports.co64.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var num = buf.readUInt32BE(0)
-  var entries = new Array(num)
-
-  for (var i = 0; i < num; i++) {
-    entries[i] = uint64be.decode(buf, i * 8 + 4)
-  }
-
-  return {
-    entries: entries
-  }
-}
-exports.co64.encodingLength = function (box) {
-  return 4 + box.entries.length * 8
-}
-
-exports.stts = {}
-exports.stts.encode = function (box, buf, offset) {
-  var entries = box.entries || []
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stts.encodingLength(box))
-
-  buf.writeUInt32BE(entries.length, 0)
-
-  for (var i = 0; i < entries.length; i++) {
-    var ptr = i * 8 + 4
-    buf.writeUInt32BE(entries[i].count || 0, ptr)
-    buf.writeUInt32BE(entries[i].duration || 0, ptr + 4)
-  }
-
-  exports.stts.encode.bytes = 4 + box.entries.length * 8
-  return buf
-}
-exports.stts.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var num = buf.readUInt32BE(0)
-  var entries = new Array(num)
-
-  for (var i = 0; i < num; i++) {
-    var ptr = i * 8 + 4
-    entries[i] = {
-      count: buf.readUInt32BE(ptr),
-      duration: buf.readUInt32BE(ptr + 4)
+    for (let i = 0; i < entries.length; i++) {
+      buf.writeUInt32BE(entries[i], i * 4 + 4)
     }
-  }
 
-  return {
-    entries: entries
-  }
-}
-exports.stts.encodingLength = function (box) {
-  return 4 + box.entries.length * 8
-}
+    exports.stco.encode.bytes = 4 + entries.length * 4
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const num = buf.readUInt32BE(0)
+    const entries = new Array(num)
 
-exports.ctts = {}
-exports.ctts.encode = function (box, buf, offset) {
-  var entries = box.entries || []
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.ctts.encodingLength(box))
-
-  buf.writeUInt32BE(entries.length, 0)
-
-  for (var i = 0; i < entries.length; i++) {
-    var ptr = i * 8 + 4
-    buf.writeUInt32BE(entries[i].count || 0, ptr)
-    buf.writeUInt32BE(entries[i].compositionOffset || 0, ptr + 4)
-  }
-
-  exports.ctts.encode.bytes = 4 + entries.length * 8
-  return buf
-}
-exports.ctts.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var num = buf.readUInt32BE(0)
-  var entries = new Array(num)
-
-  for (var i = 0; i < num; i++) {
-    var ptr = i * 8 + 4
-    entries[i] = {
-      count: buf.readUInt32BE(ptr),
-      compositionOffset: buf.readInt32BE(ptr + 4)
+    for (let i = 0; i < num; i++) {
+      entries[i] = buf.readUInt32BE(i * 4 + 4)
     }
-  }
 
-  return {
-    entries: entries
-  }
-}
-exports.ctts.encodingLength = function (box) {
-  return 4 + box.entries.length * 8
-}
-
-exports.stsc = {}
-exports.stsc.encode = function (box, buf, offset) {
-  var entries = box.entries || []
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stsc.encodingLength(box))
-
-  buf.writeUInt32BE(entries.length, 0)
-
-  for (var i = 0; i < entries.length; i++) {
-    var ptr = i * 12 + 4
-    buf.writeUInt32BE(entries[i].firstChunk || 0, ptr)
-    buf.writeUInt32BE(entries[i].samplesPerChunk || 0, ptr + 4)
-    buf.writeUInt32BE(entries[i].sampleDescriptionId || 0, ptr + 8)
-  }
-
-  exports.stsc.encode.bytes = 4 + entries.length * 12
-  return buf
-}
-exports.stsc.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var num = buf.readUInt32BE(0)
-  var entries = new Array(num)
-
-  for (var i = 0; i < num; i++) {
-    var ptr = i * 12 + 4
-    entries[i] = {
-      firstChunk: buf.readUInt32BE(ptr),
-      samplesPerChunk: buf.readUInt32BE(ptr + 4),
-      sampleDescriptionId: buf.readUInt32BE(ptr + 8)
+    return {
+      entries
     }
-  }
-
-  return {
-    entries: entries
-  }
-}
-exports.stsc.encodingLength = function (box) {
-  return 4 + box.entries.length * 12
+  },
+  encodingLength: box => 4 + box.entries.length * 4
 }
 
-exports.dref = {}
-exports.dref.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.dref.encodingLength(box))
-  var entries = box.entries || []
+exports.co64 = {
+  encode (box, buf, offset) {
+    const entries = box.entries || []
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.co64.encodingLength(box))
 
-  buf.writeUInt32BE(entries.length, 0)
+    buf.writeUInt32BE(entries.length, 0)
 
-  var ptr = 4
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i]
-    var size = (entry.buf ? entry.buf.length : 0) + 4 + 4
-
-    buf.writeUInt32BE(size, ptr)
-    ptr += 4
-
-    buf.write(entry.type, ptr, 4, 'ascii')
-    ptr += 4
-
-    if (entry.buf) {
-      entry.buf.copy(buf, ptr)
-      ptr += entry.buf.length
+    for (let i = 0; i < entries.length; i++) {
+      uint64be.encode(entries[i], buf, i * 8 + 4)
     }
-  }
 
-  exports.dref.encode.bytes = ptr
-  return buf
-}
-exports.dref.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var num = buf.readUInt32BE(0)
-  var entries = new Array(num)
-  var ptr = 4
+    exports.co64.encode.bytes = 4 + entries.length * 8
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const num = buf.readUInt32BE(0)
+    const entries = new Array(num)
 
-  for (var i = 0; i < num; i++) {
-    var size = buf.readUInt32BE(ptr)
-    var type = buf.toString('ascii', ptr + 4, ptr + 8)
-    var tmp = buf.slice(ptr + 8, ptr + size)
-    ptr += size
-
-    entries[i] = {
-      type: type,
-      buf: tmp
+    for (let i = 0; i < num; i++) {
+      entries[i] = uint64be.decode(buf, i * 8 + 4)
     }
-  }
 
-  return {
-    entries: entries
-  }
-}
-exports.dref.encodingLength = function (box) {
-  var totalSize = 4
-  if (!box.entries) return totalSize
-  for (var i = 0; i < box.entries.length; i++) {
-    var buf = box.entries[i].buf
-    totalSize += (buf ? buf.length : 0) + 4 + 4
-  }
-  return totalSize
-}
-
-exports.elst = {}
-exports.elst.encode = function (box, buf, offset) {
-  var entries = box.entries || []
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.elst.encodingLength(box))
-
-  buf.writeUInt32BE(entries.length, 0)
-
-  for (var i = 0; i < entries.length; i++) {
-    var ptr = i * 12 + 4
-    buf.writeUInt32BE(entries[i].trackDuration || 0, ptr)
-    buf.writeUInt32BE(entries[i].mediaTime || 0, ptr + 4)
-    writeFixed32(entries[i].mediaRate || 0, buf, ptr + 8)
-  }
-
-  exports.elst.encode.bytes = 4 + entries.length * 12
-  return buf
-}
-exports.elst.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  var num = buf.readUInt32BE(0)
-  var entries = new Array(num)
-
-  for (var i = 0; i < num; i++) {
-    var ptr = i * 12 + 4
-    entries[i] = {
-      trackDuration: buf.readUInt32BE(ptr),
-      mediaTime: buf.readInt32BE(ptr + 4),
-      mediaRate: readFixed32(buf, ptr + 8)
+    return {
+      entries
     }
+  },
+  encodingLength: box => 4 + box.entries.length * 8
+}
+
+exports.stts = {
+  encode (box, buf, offset) {
+    const entries = box.entries || []
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stts.encodingLength(box))
+
+    buf.writeUInt32BE(entries.length, 0)
+
+    for (let i = 0; i < entries.length; i++) {
+      const ptr = i * 8 + 4
+      buf.writeUInt32BE(entries[i].count || 0, ptr)
+      buf.writeUInt32BE(entries[i].duration || 0, ptr + 4)
+    }
+
+    exports.stts.encode.bytes = 4 + box.entries.length * 8
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const num = buf.readUInt32BE(0)
+    const entries = new Array(num)
+
+    for (let i = 0; i < num; i++) {
+      const ptr = i * 8 + 4
+      entries[i] = {
+        count: buf.readUInt32BE(ptr),
+        duration: buf.readUInt32BE(ptr + 4)
+      }
+    }
+
+    return {
+      entries
+    }
+  },
+  encodingLength: box => 4 + box.entries.length * 8
+}
+
+exports.ctts = {
+  encode (box, buf, offset) {
+    const entries = box.entries || []
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.ctts.encodingLength(box))
+
+    buf.writeUInt32BE(entries.length, 0)
+
+    for (let i = 0; i < entries.length; i++) {
+      const ptr = i * 8 + 4
+      buf.writeUInt32BE(entries[i].count || 0, ptr)
+      buf.writeUInt32BE(entries[i].compositionOffset || 0, ptr + 4)
+    }
+
+    exports.ctts.encode.bytes = 4 + entries.length * 8
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const num = buf.readUInt32BE(0)
+    const entries = new Array(num)
+
+    for (let i = 0; i < num; i++) {
+      const ptr = i * 8 + 4
+      entries[i] = {
+        count: buf.readUInt32BE(ptr),
+        compositionOffset: buf.readInt32BE(ptr + 4)
+      }
+    }
+
+    return {
+      entries
+    }
+  },
+  encodingLength: box => 4 + box.entries.length * 8
+}
+
+exports.stsc = {
+  encode (box, buf, offset) {
+    const entries = box.entries || []
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.stsc.encodingLength(box))
+
+    buf.writeUInt32BE(entries.length, 0)
+
+    for (let i = 0; i < entries.length; i++) {
+      const ptr = i * 12 + 4
+      buf.writeUInt32BE(entries[i].firstChunk || 0, ptr)
+      buf.writeUInt32BE(entries[i].samplesPerChunk || 0, ptr + 4)
+      buf.writeUInt32BE(entries[i].sampleDescriptionId || 0, ptr + 8)
+    }
+
+    exports.stsc.encode.bytes = 4 + entries.length * 12
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const num = buf.readUInt32BE(0)
+    const entries = new Array(num)
+
+    for (let i = 0; i < num; i++) {
+      const ptr = i * 12 + 4
+      entries[i] = {
+        firstChunk: buf.readUInt32BE(ptr),
+        samplesPerChunk: buf.readUInt32BE(ptr + 4),
+        sampleDescriptionId: buf.readUInt32BE(ptr + 8)
+      }
+    }
+
+    return {
+      entries
+    }
+  },
+  encodingLength: box => 4 + box.entries.length * 12
+}
+
+exports.dref = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.dref.encodingLength(box))
+    const entries = box.entries || []
+
+    buf.writeUInt32BE(entries.length, 0)
+
+    let ptr = 4
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]
+      const size = (entry.buf ? entry.buf.length : 0) + 4 + 4
+
+      buf.writeUInt32BE(size, ptr)
+      ptr += 4
+
+      buf.write(entry.type, ptr, 4, 'ascii')
+      ptr += 4
+
+      if (entry.buf) {
+        entry.buf.copy(buf, ptr)
+        ptr += entry.buf.length
+      }
+    }
+
+    exports.dref.encode.bytes = ptr
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const num = buf.readUInt32BE(0)
+    const entries = new Array(num)
+    let ptr = 4
+
+    for (let i = 0; i < num; i++) {
+      const size = buf.readUInt32BE(ptr)
+      const type = buf.toString('ascii', ptr + 4, ptr + 8)
+      const tmp = buf.slice(ptr + 8, ptr + size)
+      ptr += size
+
+      entries[i] = {
+        type,
+        buf: tmp
+      }
+    }
+
+    return {
+      entries
+    }
+  },
+  encodingLength (box) {
+    let totalSize = 4
+    if (!box.entries) return totalSize
+    for (let i = 0; i < box.entries.length; i++) {
+      const buf = box.entries[i].buf
+      totalSize += (buf ? buf.length : 0) + 4 + 4
+    }
+    return totalSize
   }
-
-  return {
-    entries: entries
-  }
-}
-exports.elst.encodingLength = function (box) {
-  return 4 + box.entries.length * 12
 }
 
-exports.hdlr = {}
-exports.hdlr.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(exports.hdlr.encodingLength(box))
+exports.elst = {
+  encode (box, buf, offset) {
+    const entries = box.entries || []
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.elst.encodingLength(box))
 
-  var len = 21 + (box.name || '').length
-  buf.fill(0, 0, len)
+    buf.writeUInt32BE(entries.length, 0)
 
-  buf.write(box.handlerType || '', 4, 4, 'ascii')
-  writeString(box.name || '', buf, 20)
+    for (let i = 0; i < entries.length; i++) {
+      const ptr = i * 12 + 4
+      buf.writeUInt32BE(entries[i].trackDuration || 0, ptr)
+      buf.writeUInt32BE(entries[i].mediaTime || 0, ptr + 4)
+      writeFixed32(entries[i].mediaRate || 0, buf, ptr + 8)
+    }
 
-  exports.hdlr.encode.bytes = len
-  return buf
-}
-exports.hdlr.decode = function (buf, offset, end) {
-  buf = buf.slice(offset)
-  return {
-    handlerType: buf.toString('ascii', 4, 8),
-    name: readString(buf, 20, end)
-  }
-}
-exports.hdlr.encodingLength = function (box) {
-  return 21 + (box.name || '').length
-}
+    exports.elst.encode.bytes = 4 + entries.length * 12
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    const num = buf.readUInt32BE(0)
+    const entries = new Array(num)
 
-exports.mehd = {}
-exports.mehd.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(4)
+    for (let i = 0; i < num; i++) {
+      const ptr = i * 12 + 4
+      entries[i] = {
+        trackDuration: buf.readUInt32BE(ptr),
+        mediaTime: buf.readInt32BE(ptr + 4),
+        mediaRate: readFixed32(buf, ptr + 8)
+      }
+    }
 
-  buf.writeUInt32BE(box.fragmentDuration || 0, 0)
-  exports.mehd.encode.bytes = 4
-  return buf
-}
-exports.mehd.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  return {
-    fragmentDuration: buf.readUInt32BE(0)
-  }
-}
-exports.mehd.encodingLength = function (box) {
-  return 4
+    return {
+      entries
+    }
+  },
+  encodingLength: box => 4 + box.entries.length * 12
 }
 
-exports.trex = {}
-exports.trex.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(20)
+exports.hdlr = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(exports.hdlr.encodingLength(box))
 
-  buf.writeUInt32BE(box.trackId || 0, 0)
-  buf.writeUInt32BE(box.defaultSampleDescriptionIndex || 0, 4)
-  buf.writeUInt32BE(box.defaultSampleDuration || 0, 8)
-  buf.writeUInt32BE(box.defaultSampleSize || 0, 12)
-  buf.writeUInt32BE(box.defaultSampleFlags || 0, 16)
-  exports.trex.encode.bytes = 20
-  return buf
-}
-exports.trex.decode = function (buf, offset) {
-  buf = buf.slice(offset)
-  return {
-    trackId: buf.readUInt32BE(0),
-    defaultSampleDescriptionIndex: buf.readUInt32BE(4),
-    defaultSampleDuration: buf.readUInt32BE(8),
-    defaultSampleSize: buf.readUInt32BE(12),
-    defaultSampleFlags: buf.readUInt32BE(16)
-  }
-}
-exports.trex.encodingLength = function (box) {
-  return 20
+    const len = 21 + (box.name || '').length
+    buf.fill(0, 0, len)
+
+    buf.write(box.handlerType || '', 4, 4, 'ascii')
+    writeString(box.name || '', buf, 20)
+
+    exports.hdlr.encode.bytes = len
+    return buf
+  },
+  decode (buf, offset, end) {
+    buf = buf.slice(offset)
+    return {
+      handlerType: buf.toString('ascii', 4, 8),
+      name: readString(buf, 20, end)
+    }
+  },
+  encodingLength: box => 21 + (box.name || '').length
 }
 
-exports.mfhd = {}
-exports.mfhd.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(4)
+exports.mehd = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(4)
 
-  buf.writeUInt32BE(box.sequenceNumber || 0, 0)
-  exports.mfhd.encode.bytes = 4
-  return buf
+    buf.writeUInt32BE(box.fragmentDuration || 0, 0)
+    exports.mehd.encode.bytes = 4
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    return {
+      fragmentDuration: buf.readUInt32BE(0)
+    }
+  },
+  encodingLength: box => 4
 }
-exports.mfhd.decode = function (buf, offset) {
-  return {
+
+exports.trex = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(20)
+
+    buf.writeUInt32BE(box.trackId || 0, 0)
+    buf.writeUInt32BE(box.defaultSampleDescriptionIndex || 0, 4)
+    buf.writeUInt32BE(box.defaultSampleDuration || 0, 8)
+    buf.writeUInt32BE(box.defaultSampleSize || 0, 12)
+    buf.writeUInt32BE(box.defaultSampleFlags || 0, 16)
+    exports.trex.encode.bytes = 20
+    return buf
+  },
+  decode (buf, offset) {
+    buf = buf.slice(offset)
+    return {
+      trackId: buf.readUInt32BE(0),
+      defaultSampleDescriptionIndex: buf.readUInt32BE(4),
+      defaultSampleDuration: buf.readUInt32BE(8),
+      defaultSampleSize: buf.readUInt32BE(12),
+      defaultSampleFlags: buf.readUInt32BE(16)
+    }
+  },
+  encodingLength: box => 20
+}
+
+exports.mfhd = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(4)
+
+    buf.writeUInt32BE(box.sequenceNumber || 0, 0)
+    exports.mfhd.encode.bytes = 4
+    return buf
+  },
+  decode: (buf, offset) => ({
     sequenceNumber: buf.readUInt32BE(0)
-  }
-}
-exports.mfhd.encodingLength = function (box) {
-  return 4
+  }),
+  encodingLength: box => 4
 }
 
-exports.tfhd = {}
-exports.tfhd.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(4)
-  buf.writeUInt32BE(box.trackId, 0)
-  exports.tfhd.encode.bytes = 4
-  return buf
+exports.tfhd = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(4)
+    buf.writeUInt32BE(box.trackId, 0)
+    exports.tfhd.encode.bytes = 4
+    return buf
+  },
+  decode (buf, offset) {
+    // TODO: this
+  },
+  encodingLength: box => 4 // TODO: this is wrong!
 }
-exports.tfhd.decode = function (buf, offset) {
+
+exports.tfdt = {
+  encode (box, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(4)
+
+    buf.writeUInt32BE(box.baseMediaDecodeTime || 0, 0)
+    exports.tfdt.encode.bytes = 4
+    return buf
+  },
+  decode (buf, offset) {
   // TODO: this
-}
-exports.tfhd.encodingLength = function (box) {
-  // TODO: this is wrong!
-  return 4
+  },
+  encodingLength: box => 4
 }
 
-exports.tfdt = {}
-exports.tfdt.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(4)
+exports.trun = {
+  encode ({ entries, dataOffset, version }, buf, offset) {
+    buf = buf ? buf.slice(offset) : Buffer.alloc(8 + entries.length * 16)
 
-  buf.writeUInt32BE(box.baseMediaDecodeTime || 0, 0)
-  exports.tfdt.encode.bytes = 4
-  return buf
-}
-exports.tfdt.decode = function (buf, offset) {
-  // TODO: this
-}
-exports.tfdt.encodingLength = function (box) {
-  return 4
-}
+    // TODO: this is wrong
+    buf.writeUInt32BE(entries.length, 0)
+    buf.writeInt32BE(dataOffset, 4)
+    let ptr = 8
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]
+      buf.writeUInt32BE(entry.sampleDuration, ptr)
+      ptr += 4
 
-exports.trun = {}
-exports.trun.encode = function (box, buf, offset) {
-  buf = buf ? buf.slice(offset) : Buffer.alloc(8 + box.entries.length * 16)
+      buf.writeUInt32BE(entry.sampleSize, ptr)
+      ptr += 4
 
-  // TODO: this is wrong
-  buf.writeUInt32BE(box.entries.length, 0)
-  buf.writeInt32BE(box.dataOffset, 4)
-  var ptr = 8
-  for (var i = 0; i < box.entries.length; i++) {
-    var entry = box.entries[i]
-    buf.writeUInt32BE(entry.sampleDuration, ptr)
-    ptr += 4
+      buf.writeUInt32BE(entry.sampleFlags, ptr)
+      ptr += 4
 
-    buf.writeUInt32BE(entry.sampleSize, ptr)
-    ptr += 4
-
-    buf.writeUInt32BE(entry.sampleFlags, ptr)
-    ptr += 4
-
-    if ((box.version || 0) === 0) {
-      buf.writeUInt32BE(entry.sampleCompositionTimeOffset, ptr)
-    } else {
-      buf.writeInt32BE(entry.sampleCompositionTimeOffset, ptr)
+      if ((version || 0) === 0) {
+        buf.writeUInt32BE(entry.sampleCompositionTimeOffset, ptr)
+      } else {
+        buf.writeInt32BE(entry.sampleCompositionTimeOffset, ptr)
+      }
+      ptr += 4
     }
-    ptr += 4
-  }
-  exports.trun.encode.bytes = ptr
-}
-exports.trun.decode = function (buf, offset) {
+    exports.trun.encode.bytes = ptr
+  },
   // TODO: this
-}
-exports.trun.encodingLength = function (box) {
+  decode (buf, offset) {},
   // TODO: this is wrong
-  return 8 + box.entries.length * 16
+  encodingLength: box => 8 + box.entries.length * 16
 }
 
-exports.mdat = {}
-exports.mdat.encode = function (box, buf, offset) {
-  if (box.buffer) {
-    box.buffer.copy(buf, offset)
-    exports.mdat.encode.bytes = box.buffer.length
-  } else {
-    exports.mdat.encode.bytes = exports.mdat.encodingLength(box)
-  }
-}
-exports.mdat.decode = function (buf, start, end) {
-  return {
+exports.mdat = {
+  encode (box, buf, offset) {
+    if (box.buffer) {
+      box.buffer.copy(buf, offset)
+      exports.mdat.encode.bytes = box.buffer.length
+    } else {
+      exports.mdat.encode.bytes = exports.mdat.encodingLength(box)
+    }
+  },
+  decode: (buf, start, end) => ({
     buffer: Buffer.from(buf.slice(start, end))
-  }
-}
-exports.mdat.encodingLength = function (box) {
-  return box.buffer ? box.buffer.length : box.contentLength
+  }),
+  encodingLength: box => box.buffer ? box.buffer.length : box.contentLength
 }
 
 function writeReserved (buf, offset, end) {
-  for (var i = offset; i < end; i++) buf[i] = 0
+  for (let i = offset; i < end; i++) buf[i] = 0
 }
 
 function writeDate (date, buf, offset) {
@@ -963,20 +937,20 @@ function writeFixed16 (num, buf, offset) {
 
 function writeMatrix (list, buf, offset) {
   if (!list) list = [0, 0, 0, 0, 0, 0, 0, 0, 0]
-  for (var i = 0; i < list.length; i++) {
+  for (let i = 0; i < list.length; i++) {
     writeFixed32(list[i], buf, offset + i * 4)
   }
 }
 
 function writeString (str, buf, offset) {
-  var strBuffer = Buffer.from(str, 'utf8')
+  const strBuffer = Buffer.from(str, 'utf8')
   strBuffer.copy(buf, offset)
   buf[offset + strBuffer.length] = 0
 }
 
 function readMatrix (buf) {
-  var list = new Array(buf.length / 4)
-  for (var i = 0; i < list.length; i++) list[i] = readFixed32(buf, i * 4)
+  const list = new Array(buf.length / 4)
+  for (let i = 0; i < list.length; i++) list[i] = readFixed32(buf, i * 4)
   return list
 }
 
@@ -998,7 +972,7 @@ function readFixed16 (buf, offset) {
 }
 
 function readString (buf, offset, length) {
-  var i
+  let i
   for (i = 0; i < length; i++) {
     if (buf[offset + i] === 0) {
       break

--- a/descriptor.js
+++ b/descriptor.js
@@ -1,72 +1,76 @@
-var tagToName = {
+const tagToName = {
   0x03: 'ESDescriptor',
   0x04: 'DecoderConfigDescriptor',
   0x05: 'DecoderSpecificInfo',
   0x06: 'SLConfigDescriptor'
 }
 
-exports.Descriptor = {}
-exports.Descriptor.decode = function (buf, start, end) {
-  var tag = buf.readUInt8(start)
-  var ptr = start + 1
-  var lenByte
-  var len = 0
-  do {
-    lenByte = buf.readUInt8(ptr++)
-    len = (len << 7) | (lenByte & 0x7f)
-  } while (lenByte & 0x80)
+exports.Descriptor = {
+  decode (buf, start, end) {
+    const tag = buf.readUInt8(start)
+    let ptr = start + 1
+    let lenByte
+    let len = 0
+    do {
+      lenByte = buf.readUInt8(ptr++)
+      len = (len << 7) | (lenByte & 0x7f)
+    } while (lenByte & 0x80)
 
-  var obj
-  var tagName = tagToName[tag] // May be undefined; that's ok
-  if (exports[tagName]) {
-    obj = exports[tagName].decode(buf, ptr, end)
-  } else {
-    obj = {
-      buffer: Buffer.from(buf.slice(ptr, ptr + len))
+    let obj
+    const tagName = tagToName[tag] // May be undefined; that's ok
+    if (exports[tagName]) {
+      obj = exports[tagName].decode(buf, ptr, end)
+    } else {
+      obj = {
+        buffer: Buffer.from(buf.slice(ptr, ptr + len))
+      }
     }
-  }
 
-  obj.tag = tag
-  obj.tagName = tagName
-  obj.length = (ptr - start) + len
-  obj.contentsLen = len
-  return obj
+    obj.tag = tag
+    obj.tagName = tagName
+    obj.length = (ptr - start) + len
+    obj.contentsLen = len
+    return obj
+  }
 }
 
-exports.DescriptorArray = {}
-exports.DescriptorArray.decode = function (buf, start, end) {
-  var ptr = start
-  var obj = {}
-  while (ptr + 2 <= end) {
-    var descriptor = exports.Descriptor.decode(buf, ptr, end)
-    ptr += descriptor.length
-    var tagName = tagToName[descriptor.tag] || ('Descriptor' + descriptor.tag)
-    obj[tagName] = descriptor
+exports.DescriptorArray = {
+  decode (buf, start, end) {
+    let ptr = start
+    const obj = {}
+    while (ptr + 2 <= end) {
+      const descriptor = exports.Descriptor.decode(buf, ptr, end)
+      ptr += descriptor.length
+      const tagName = tagToName[descriptor.tag] || (`Descriptor${descriptor.tag}`)
+      obj[tagName] = descriptor
+    }
+    return obj
   }
-  return obj
 }
 
-exports.ESDescriptor = {}
-exports.ESDescriptor.decode = function (buf, start, end) {
-  var flags = buf.readUInt8(start + 2)
-  var ptr = start + 3
-  if (flags & 0x80) {
-    ptr += 2
+exports.ESDescriptor = {
+  decode (buf, start, end) {
+    const flags = buf.readUInt8(start + 2)
+    let ptr = start + 3
+    if (flags & 0x80) {
+      ptr += 2
+    }
+    if (flags & 0x40) {
+      const len = buf.readUInt8(ptr)
+      ptr += len + 1
+    }
+    if (flags & 0x20) {
+      ptr += 2
+    }
+    return exports.DescriptorArray.decode(buf, ptr, end)
   }
-  if (flags & 0x40) {
-    var len = buf.readUInt8(ptr)
-    ptr += len + 1
-  }
-  if (flags & 0x20) {
-    ptr += 2
-  }
-  return exports.DescriptorArray.decode(buf, ptr, end)
 }
 
-exports.DecoderConfigDescriptor = {}
-exports.DecoderConfigDescriptor.decode = function (buf, start, end) {
-  var oti = buf.readUInt8(start)
-  var obj = exports.DescriptorArray.decode(buf, start + 13, end)
-  obj.oti = oti
-  return obj
+exports.DecoderConfigDescriptor = {
+  decode (buf, start, end) {
+    const oti = buf.readUInt8(start)
+    const obj = exports.DescriptorArray.decode(buf, start + 13, end)
+    obj.oti = oti
+    return obj
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,9 @@
   "author": "John Hiesey",
   "license": "MIT",
   "dependencies": {
-    "uint64be": "^2.0.2"
+    "uint64be": "^3.0.0"
   },
   "devDependencies": {
-    "standard": "^11.0.1",
-    "tape": "^4.9.1"
+    "standard": "^16.0.3"
   }
 }


### PR DESCRIPTION
I was gona try to convert this to ESM but all the `exports[xxxx]encode.bytes = x` made it a bit weird.

So i just converted most of the code to use const and let, some default arguments here and there and some arrow fn and also reduced the number of exports by doing something like:
```diff
- exports.esds = {}
- exports.esds.encode = fn
- exports.esds.decode = fn
- exports.esds.encodingLength = fn

+ exports.esds = {
+  encode(...args) { ...}
+  decode(...args) { ...}
+  encodingLength(...args) { ...}
+ }
```

The conversion was mostly done with lebab. Didn't want to do too many changes - afraid to do any breaking stuff when there are no tests...
but the conversion to export an object instead makes it easier to iterate over to try and modernize it a bit furtherer 

(have also updated all the dependencies)